### PR TITLE
SRA-28 Sudoku add difficulty not resetting after save

### DIFF
--- a/src/components/SudokuAdd/SudokuAdd.js
+++ b/src/components/SudokuAdd/SudokuAdd.js
@@ -59,7 +59,6 @@ class SudokuAdd extends Component {
         })
         this.setState({
           errorMessage: null,
-          difficulty: 'easy',
           gridObj: gridCreator('000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
         })
       } else {


### PR DESCRIPTION
    DESCRIPTION: Removed line which sets sudoku difficulty state to easy
    because it did not change selected difficulty to easy after each
    save. Now after saving sudoku with specific difficulty, difficulty
    selection stays as it was selected.